### PR TITLE
Remove NOT_RESTORED guard

### DIFF
--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -329,7 +329,7 @@
             @"event": @"stateChanged"
         }];
     });
-    
+
     // Additionally emit restored event when manager becomes powered on (if not already restored)
     // This ensures the event fires on every app launch, not just during state restoration
     if (state == FLICManagerStatePoweredOn && !self.managerRestored) {

--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -32,11 +32,6 @@
         return;
     }
 
-    if (!self.managerRestored) {
-        reject(@"NOT_RESTORED", @"Manager not restored yet. Wait for managerDidRestoreState", nil);
-        return;
-    }
-
     NSArray<FLICButton *> *buttons = [[FLICManager sharedManager] buttons];
     NSMutableArray *buttonDicts = [[NSMutableArray alloc] init];
 

--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -312,6 +312,8 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             [self emitOnManagerStateChange:@{
                 @"event": @"restored",
+                @"state": @(manager.state),
+                @"stateName": [self managerStateToString:manager.state],
                 @"message": @"Manager state restored"
             }];
         });
@@ -319,7 +321,16 @@
 }
 
 - (void)manager:(FLICManager *)manager didUpdateState:(FLICManagerState)state {
-    // Emit restored event when manager becomes powered on (if not already restored)
+    // Always emit stateChanged for every state change
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self emitOnManagerStateChange:@{
+            @"state": @(state),
+            @"stateName": [self managerStateToString:state],
+            @"event": @"stateChanged"
+        }];
+    });
+    
+    // Additionally emit restored event when manager becomes powered on (if not already restored)
     // This ensures the event fires on every app launch, not just during state restoration
     if (state == FLICManagerStatePoweredOn && !self.managerRestored) {
         self.managerRestored = YES;
@@ -330,15 +341,6 @@
                 @"state": @(state),
                 @"stateName": [self managerStateToString:state],
                 @"message": @"Manager ready"
-            }];
-        });
-    } else {
-        // Emit regular state change event
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self emitOnManagerStateChange:@{
-                @"state": @(state),
-                @"stateName": [self managerStateToString:state],
-                @"event": @"stateChanged"
             }];
         });
     }

--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -305,24 +305,43 @@
 // MARK: - FLICManagerDelegate
 
 - (void)managerDidRestoreState:(FLICManager *)manager {
-    self.managerRestored = YES;
-    NSLog(@"Manager state restored - ready for operations");
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self emitOnManagerStateChange:@{
-            @"event": @"restored",
-            @"message": @"Manager state restored"
-        }];
-    });
+    // Only emit restored event if we haven't already done so
+    if (!self.managerRestored) {
+        self.managerRestored = YES;
+        NSLog(@"Manager state restored - ready for operations");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self emitOnManagerStateChange:@{
+                @"event": @"restored",
+                @"message": @"Manager state restored"
+            }];
+        });
+    }
 }
 
 - (void)manager:(FLICManager *)manager didUpdateState:(FLICManagerState)state {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self emitOnManagerStateChange:@{
-            @"state": @(state),
-            @"stateName": [self managerStateToString:state],
-            @"event": @"stateChanged"
-        }];
-    });
+    // Emit restored event when manager becomes powered on (if not already restored)
+    // This ensures the event fires on every app launch, not just during state restoration
+    if (state == FLICManagerStatePoweredOn && !self.managerRestored) {
+        self.managerRestored = YES;
+        NSLog(@"Manager powered on - ready for operations");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self emitOnManagerStateChange:@{
+                @"event": @"restored",
+                @"state": @(state),
+                @"stateName": [self managerStateToString:state],
+                @"message": @"Manager ready"
+            }];
+        });
+    } else {
+        // Emit regular state change event
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self emitOnManagerStateChange:@{
+                @"state": @(state),
+                @"stateName": [self managerStateToString:state],
+                @"event": @"stateChanged"
+            }];
+        });
+    }
 }
 
 // MARK: - FLICButtonDelegate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.17",
+  "version": "2.0.0-beta.18",
   "description": "React Native Flic plugin made with the Flic2 SDK (unofficial)",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.18",
+  "version": "2.0.0-beta.19",
   "description": "React Native Flic plugin made with the Flic2 SDK (unofficial)",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "React Native Flic plugin made with the Flic2 SDK (unofficial)",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,6 +336,13 @@ class Flic2 {
    */
   private onNativeManagerStateChange(event: ManagerStateChangeEvent): void {
 
+    // When manager is restored, mark it as initialized
+    if (event.event === 'restored' && !this.isFlic2ManagerInitialized) {
+
+      this.onInitialized();
+
+    }
+
     this.eventEmitter.emit('managerStateChange', event);
 
   }


### PR DESCRIPTION
This change removes the `managerRestored` guard from `getButtons` so that it no longer rejects with `NOT_RESTORED` and instead always returns the current list of buttons once `FLICManager` is configured. In the old Objective‑C implementation, `getButtons` simply read `FLICManager.sharedManager.buttons` (possibly empty) without depending on `managerDidRestoreState`, which is only invoked during iOS state restoration and not on a fresh launch. By introducing `managerRestored` as a hard precondition, the new TurboModule implementation caused `getButtons` to fail with `NOT_RESTORED` on normal first‑run usage, even though the manager was initialized correctly. Aligning `getButtons` with the old behavior fixes that regression while still keeping the `NOT_INITIALIZED` guard and leaving `managerDidRestoreState` for logging and event emission only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `getButtons` no longer requires manager restore; manager state events are more consistent, JS marks initialized on restored; version bumped to beta.19.
> 
> - **iOS (`ios/Flic2.mm`)**
>   - `getButtons`: remove `managerRestored` precondition so it always returns current buttons when manager is configured.
>   - **Manager events**:
>     - Emit `restored` only once and include `state`/`stateName`.
>     - Always emit `stateChanged`; also emit `restored` when powered on if not previously restored.
> - **JS (`src/index.ts`)**
>   - On `managerStateChange` with `event==='restored'`, mark manager as initialized.
> - **Package**
>   - Bump version to `2.0.0-beta.19`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7431b673d90db355a2af87ddbe91e025325699d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->