### PR TITLE
fix: make initialize() resolve only when native manager is ready

### DIFF
--- a/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
@@ -51,20 +51,32 @@ class Flic2Module(reactContext: ReactApplicationContext) :
       flic2Service = (service as Flic2Service.Flic2ServiceBinder).getService()
       serviceBound = true
 
-      // Set up listeners for existing buttons
-      flic2Service?.getManager()?.let { manager ->
-        manager.buttons.forEach { button ->
-          setupButtonListener(button)
+      // ponytail: initialize() must only resolve when getManager() is non-null;
+      // service bind alone is not enough (Flic2Manager.init can fail in onCreate).
+      val manager = flic2Service?.getManager()
+      if (manager == null) {
+        Log.e(TAG, "Service connected but Flic2Manager is null")
+        initializePromise?.let { promise ->
+          promise.reject("INIT_ERROR", "Flic2Manager failed to initialize in service")
+          initializePromise = null
         }
-        // Update foreground service state based on button count
-        updateForegroundServiceState(manager.buttons.size)
+        return
       }
 
-      // Resolve the initialize promise if pending
+      manager.buttons.forEach { button ->
+        setupButtonListener(button)
+      }
+      updateForegroundServiceState(manager.buttons.size)
+
       initializePromise?.let { promise ->
         promise.resolve(null)
         initializePromise = null
       }
+
+      emitOnManagerStateChange(Arguments.createMap().apply {
+        putString("event", "restored")
+        putString("message", "Manager ready")
+      })
     }
 
     override fun onServiceDisconnected(name: ComponentName?) {
@@ -122,7 +134,13 @@ class Flic2Module(reactContext: ReactApplicationContext) :
 
   override fun initialize(background: Boolean, promise: Promise) {
     try {
-      // Store the promise to resolve when service is connected
+      // Already bound with a live manager — ready for API calls.
+      if (serviceBound && flic2Service?.getManager() != null) {
+        promise.resolve(null)
+        return
+      }
+
+      // Store the promise to resolve when service is connected and manager is ready
       initializePromise = promise
 
       val intent = Intent(reactApplicationContext, Flic2Service::class.java)

--- a/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
@@ -106,6 +106,15 @@ class Flic2Module(reactContext: ReactApplicationContext) :
     }
     serviceBound = false
     flic2Service = null
+    // Stop the service so a later initialize() re-runs onCreate (and Flic2Manager.init).
+    // Unbind alone leaves a dead instance running with a null manager.
+    try {
+      reactApplicationContext.stopService(
+        Intent(reactApplicationContext, Flic2Service::class.java)
+      )
+    } catch (e: Exception) {
+      Log.w(TAG, "Failed to stop Flic2Service after manager init failure", e)
+    }
   }
 
   override fun getName(): String {

--- a/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
@@ -51,7 +51,7 @@ class Flic2Module(reactContext: ReactApplicationContext) :
       flic2Service = (service as Flic2Service.Flic2ServiceBinder).getService()
       serviceBound = true
 
-      // ponytail: initialize() must only resolve when getManager() is non-null;
+      // initialize() must only resolve when getManager() is non-null;
       // service bind alone is not enough (Flic2Manager.init can fail in onCreate).
       val manager = flic2Service?.getManager()
       if (manager == null) {
@@ -59,6 +59,10 @@ class Flic2Module(reactContext: ReactApplicationContext) :
         initializePromise?.let { promise ->
           promise.reject("INIT_ERROR", "Flic2Manager failed to initialize in service")
           initializePromise = null
+        }
+        // Unbind on next loop so a later initialize() can bind again and retry.
+        moduleScope.launch {
+          resetServiceBinding()
         }
         return
       }
@@ -90,6 +94,18 @@ class Flic2Module(reactContext: ReactApplicationContext) :
         initializePromise = null
       }
     }
+  }
+
+  private fun resetServiceBinding() {
+    if (serviceBound) {
+      try {
+        reactApplicationContext.unbindService(serviceConnection)
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to unbind after manager init failure", e)
+      }
+    }
+    serviceBound = false
+    flic2Service = null
   }
 
   override fun getName(): String {
@@ -137,6 +153,18 @@ class Flic2Module(reactContext: ReactApplicationContext) :
       // Already bound with a live manager — ready for API calls.
       if (serviceBound && flic2Service?.getManager() != null) {
         promise.resolve(null)
+        return
+      }
+
+      // Bound but manager missing: onServiceConnected will not fire again.
+      if (serviceBound && flic2Service?.getManager() == null) {
+        resetServiceBinding()
+        promise.reject("INIT_ERROR", "Flic2Manager failed to initialize in service")
+        return
+      }
+
+      if (initializePromise != null) {
+        promise.reject("INIT_IN_PROGRESS", "Initialize already in progress")
         return
       }
 

--- a/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
@@ -5,7 +5,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -60,8 +62,9 @@ class Flic2Module(reactContext: ReactApplicationContext) :
           promise.reject("INIT_ERROR", "Flic2Manager failed to initialize in service")
           initializePromise = null
         }
-        // Unbind on next loop so a later initialize() can bind again and retry.
-        moduleScope.launch {
+        // Unbind/stop on next loop so a later initialize() can restart the service.
+        // Use Handler (not moduleScope) so invalidate()'s scope.cancel cannot skip stopService.
+        Handler(Looper.getMainLooper()).post {
           resetServiceBinding()
         }
         return
@@ -148,11 +151,14 @@ class Flic2Module(reactContext: ReactApplicationContext) :
     // Clear listeners map
     buttonListeners.clear()
 
-    moduleScope.cancel()
-    if (serviceBound) {
-      reactApplicationContext.unbindService(serviceConnection)
-      serviceBound = false
+    initializePromise?.let { promise ->
+      promise.reject("MODULE_INVALIDATED", "Flic2 native module was invalidated")
+      initializePromise = null
     }
+
+    moduleScope.cancel()
+    // Unbind + stopService even if a pending reset was cancelled with the scope.
+    resetServiceBinding()
   }
 
   // MARK: - Manager Methods

--- a/ios/Flic2.h
+++ b/ios/Flic2.h
@@ -8,5 +8,6 @@
 
 @property (nonatomic, assign) BOOL managerRestored;
 @property (nonatomic, copy, nullable) RCTPromiseResolveBlock initializeResolve;
+@property (nonatomic, copy, nullable) RCTPromiseRejectBlock initializeReject;
 
 @end

--- a/ios/Flic2.h
+++ b/ios/Flic2.h
@@ -8,6 +8,5 @@
 
 @property (nonatomic, assign) BOOL managerRestored;
 @property (nonatomic, copy, nullable) RCTPromiseResolveBlock initializeResolve;
-@property (nonatomic, copy, nullable) RCTPromiseRejectBlock initializeReject;
 
 @end

--- a/ios/Flic2.h
+++ b/ios/Flic2.h
@@ -7,5 +7,7 @@
 @interface Flic2 : NativeFlic2SpecBase <NativeFlic2Spec, FLICManagerDelegate, FLICButtonDelegate>
 
 @property (nonatomic, assign) BOOL managerRestored;
+@property (nonatomic, copy, nullable) RCTPromiseResolveBlock initializeResolve;
+@property (nonatomic, copy, nullable) RCTPromiseRejectBlock initializeReject;
 
 @end

--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -1,6 +1,10 @@
 #import "Flic2.h"
 #import <React/RCTBridgeModule.h>
 
+// FLICManager only fires managerDidRestoreState once per process. Track it so a
+// new RN module instance (hot reload / remount) can still resolve initialize().
+static BOOL Flic2ManagerDidRestoreOnce = NO;
+
 @implementation Flic2
 
 - (instancetype)init {
@@ -17,16 +21,29 @@
     }
     RCTPromiseResolveBlock resolve = self.initializeResolve;
     self.initializeResolve = nil;
-    self.initializeReject = nil;
     resolve(nil);
+}
+
+- (void)markManagerRestoredAndResolve
+{
+    self.managerRestored = YES;
+    Flic2ManagerDidRestoreOnce = YES;
+    [self resolveInitializeIfPending];
 }
 
 - (void)initialize:(BOOL)background
     resolve:(RCTPromiseResolveBlock)resolve
     reject:(RCTPromiseRejectBlock)reject
 {
-    // Already restored — ready for API calls (including scan).
+    // Already restored on this instance — ready for API calls (including scan).
     if (self.managerRestored && [FLICManager sharedManager]) {
+        resolve(nil);
+        return;
+    }
+
+    // Process already restored (e.g. RN remount); restore callbacks will not re-fire.
+    if (Flic2ManagerDidRestoreOnce && [FLICManager sharedManager]) {
+        self.managerRestored = YES;
         resolve(nil);
         return;
     }
@@ -45,13 +62,14 @@
         return;
     }
 
-    if (self.managerRestored) {
+    if (self.managerRestored || Flic2ManagerDidRestoreOnce) {
+        self.managerRestored = YES;
+        Flic2ManagerDidRestoreOnce = YES;
         resolve(nil);
         return;
     }
 
     self.initializeResolve = resolve;
-    self.initializeReject = reject;
 }
 
 - (void)getButtons:(RCTPromiseResolveBlock)resolve
@@ -332,9 +350,8 @@
 - (void)managerDidRestoreState:(FLICManager *)manager {
     // Only emit restored event if we haven't already done so
     if (!self.managerRestored) {
-        self.managerRestored = YES;
         NSLog(@"Manager state restored - ready for operations");
-        [self resolveInitializeIfPending];
+        [self markManagerRestoredAndResolve];
         dispatch_async(dispatch_get_main_queue(), ^{
             [self emitOnManagerStateChange:@{
                 @"event": @"restored",
@@ -359,9 +376,8 @@
     // Additionally emit restored event when manager becomes powered on (if not already restored)
     // This ensures the event fires on every app launch, not just during state restoration
     if (state == FLICManagerStatePoweredOn && !self.managerRestored) {
-        self.managerRestored = YES;
         NSLog(@"Manager powered on - ready for operations");
-        [self resolveInitializeIfPending];
+        [self markManagerRestoredAndResolve];
         dispatch_async(dispatch_get_main_queue(), ^{
             [self emitOnManagerStateChange:@{
                 @"event": @"restored",

--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -10,18 +10,48 @@
 
 // MARK: - FLICManager Methods
 
+- (void)resolveInitializeIfPending
+{
+    if (!self.initializeResolve) {
+        return;
+    }
+    RCTPromiseResolveBlock resolve = self.initializeResolve;
+    self.initializeResolve = nil;
+    self.initializeReject = nil;
+    resolve(nil);
+}
+
 - (void)initialize:(BOOL)background
     resolve:(RCTPromiseResolveBlock)resolve
     reject:(RCTPromiseRejectBlock)reject
 {
-    // Configure the shared manager (this is the correct way)
+    // Already restored — ready for API calls (including scan).
+    if (self.managerRestored && [FLICManager sharedManager]) {
+        resolve(nil);
+        return;
+    }
+
+    if (self.initializeResolve) {
+        reject(@"INIT_IN_PROGRESS", @"Initialize already in progress", nil);
+        return;
+    }
+
+    // Configure the shared manager; resolve only after managerRestored
+    // (managerDidRestoreState / PoweredOn) so await initialize() is honest.
     FLICManager *manager = [FLICManager configureWithDelegate:self buttonDelegate:self background:background];
 
-    if (manager) {
-        resolve(nil);
-    } else {
+    if (!manager) {
         reject(@"INIT_ERROR", @"Failed to initialize FLICManager", nil);
+        return;
     }
+
+    if (self.managerRestored) {
+        resolve(nil);
+        return;
+    }
+
+    self.initializeResolve = resolve;
+    self.initializeReject = reject;
 }
 
 - (void)getButtons:(RCTPromiseResolveBlock)resolve
@@ -47,11 +77,6 @@
 {
     if (![FLICManager sharedManager]) {
         reject(@"NOT_INITIALIZED", @"Manager not initialized", nil);
-        return;
-    }
-
-    if (!self.managerRestored) {
-        reject(@"NOT_RESTORED", @"Manager not restored yet. Wait for managerDidRestoreState", nil);
         return;
     }
 
@@ -309,6 +334,7 @@
     if (!self.managerRestored) {
         self.managerRestored = YES;
         NSLog(@"Manager state restored - ready for operations");
+        [self resolveInitializeIfPending];
         dispatch_async(dispatch_get_main_queue(), ^{
             [self emitOnManagerStateChange:@{
                 @"event": @"restored",
@@ -335,6 +361,7 @@
     if (state == FLICManagerStatePoweredOn && !self.managerRestored) {
         self.managerRestored = YES;
         NSLog(@"Manager powered on - ready for operations");
+        [self resolveInitializeIfPending];
         dispatch_async(dispatch_get_main_queue(), ^{
             [self emitOnManagerStateChange:@{
                 @"event": @"restored",

--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -135,6 +135,13 @@ static BOOL Flic2ManagerDidRestoreOnce = NO;
         return;
     }
 
+    // Belt-and-suspenders: sharedManager exists after configure, before restore.
+    // Callers must await initialize(); reject clearly if they race it.
+    if (!self.managerRestored) {
+        reject(@"NOT_RESTORED", @"Manager not restored yet. Await Flic2.initialize()", nil);
+        return;
+    }
+
     NSLog(@"Starting scan");
 
     __weak Flic2 *weakSelf = self;

--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -21,7 +21,34 @@ static BOOL Flic2ManagerDidRestoreOnce = NO;
     }
     RCTPromiseResolveBlock resolve = self.initializeResolve;
     self.initializeResolve = nil;
+    self.initializeReject = nil;
     resolve(nil);
+}
+
+- (void)rejectInitializeIfPending:(NSString *)code message:(NSString *)message
+{
+    if (!self.initializeReject) {
+        self.initializeResolve = nil;
+        return;
+    }
+    RCTPromiseRejectBlock reject = self.initializeReject;
+    self.initializeResolve = nil;
+    self.initializeReject = nil;
+    reject(code, message, nil);
+}
+
+- (void)reattachDelegatesToSharedManager
+{
+    FLICManager *manager = [FLICManager sharedManager];
+    if (!manager) {
+        return;
+    }
+    // Weak delegates die with the previous RN module instance on remount.
+    manager.delegate = self;
+    manager.buttonDelegate = self;
+    for (FLICButton *button in manager.buttons) {
+        button.delegate = self;
+    }
 }
 
 - (void)markManagerRestoredAndResolve
@@ -31,18 +58,27 @@ static BOOL Flic2ManagerDidRestoreOnce = NO;
     [self resolveInitializeIfPending];
 }
 
+- (void)invalidate
+{
+    [self rejectInitializeIfPending:@"MODULE_INVALIDATED" message:@"Flic2 native module was invalidated"];
+    [super invalidate];
+}
+
 - (void)initialize:(BOOL)background
     resolve:(RCTPromiseResolveBlock)resolve
     reject:(RCTPromiseRejectBlock)reject
 {
     // Already restored on this instance — ready for API calls (including scan).
     if (self.managerRestored && [FLICManager sharedManager]) {
+        [self reattachDelegatesToSharedManager];
         resolve(nil);
         return;
     }
 
     // Process already restored (e.g. RN remount); restore callbacks will not re-fire.
+    // JS Flic2 is a singleton, but the native module instance is not — re-attach delegates.
     if (Flic2ManagerDidRestoreOnce && [FLICManager sharedManager]) {
+        [self reattachDelegatesToSharedManager];
         self.managerRestored = YES;
         resolve(nil);
         return;
@@ -70,6 +106,7 @@ static BOOL Flic2ManagerDidRestoreOnce = NO;
     }
 
     self.initializeResolve = resolve;
+    self.initializeReject = reject;
 }
 
 - (void)getButtons:(RCTPromiseResolveBlock)resolve

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ class Flic2 {
 
   private isFlic2ManagerInitialized: boolean = false;
 
+  private initializePromise: Promise<void> | null = null;
+
   public eventEmitter: TypedEmitter<{
     buttonEvent: (event: ButtonEvent) => void;
     managerStateChange: (event: ManagerStateChangeEvent) => void;
@@ -49,7 +51,8 @@ class Flic2 {
    *
    * Resolves when the native manager is ready for API calls
    * (`getButtons`, `connectAllKnownButtons`, `startScan`, etc.).
-   * Idempotent: returns immediately if already initialized.
+   * Idempotent: concurrent and repeat calls share one in-flight promise
+   * or return immediately once ready.
    *
    * @returns A promise that resolves when the Flic2 manager is ready.
    */
@@ -61,9 +64,24 @@ class Flic2 {
 
     }
 
-    await NativeFlic2.initialize(true);
+    if (this.initializePromise) {
 
-    this.onInitialized();
+      return this.initializePromise;
+
+    }
+
+    this.initializePromise = (async () => {
+
+      await NativeFlic2.initialize(true);
+      this.onInitialized();
+
+    })().finally(() => {
+
+      this.initializePromise = null;
+
+    });
+
+    return this.initializePromise;
 
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,18 +47,20 @@ class Flic2 {
   /**
    * Initialize the Flic2 manager.
    *
-   * @returns A promise that resolves when the Flic2 manager is initialized.
+   * Resolves when the native manager is ready for API calls
+   * (`getButtons`, `connectAllKnownButtons`, `startScan`, etc.).
+   * Idempotent: returns immediately if already initialized.
+   *
+   * @returns A promise that resolves when the Flic2 manager is ready.
    */
   public async initialize(): Promise<void> {
 
-    // check if the Flic2 manager is already initialized
     if (this.isInitialized()) {
 
-      throw new Error('Flic2 manager is already initialized');
+      return;
 
     }
 
-    // initialize the Flic2 manager in background
     await NativeFlic2.initialize(true);
 
     this.onInitialized();


### PR DESCRIPTION
## Summary
- **Android:** resolve `initialize()` only when `getManager()` is non-null after service bind; emit `managerStateChange` `{ event: "restored" }` so JS readiness matches iOS.
- **iOS:** defer `initialize()` resolve until `managerRestored` (`managerDidRestoreState` / PoweredOn). Keep a `NOT_RESTORED` gate on `startScan` as belt-and-suspenders for callers that race an in-flight `initialize()` (preferred path is still `await initialize()`).
- **JS:** document that `await initialize()` means APIs are safe; make re-init idempotent (return instead of throw).

Fixes the library-level `NOT_INITIALIZED` / readiness race where `await initialize()` could resolve before the native manager was usable.

## Test plan
- [ ] Android: `await Flic2.initialize()` then immediately `getButtons()` / `connectAllKnownButtons()` / `startScan()` — no `NOT_INITIALIZED`
- [ ] Android: confirm `managerStateChange` with `event: "restored"` after init
- [ ] iOS: same sequence after `await initialize()` — scan works; calling `startScan` before restore still rejects `NOT_RESTORED`
- [ ] Second `Flic2.initialize()` returns without throwing
- [ ] After merge: publish a new beta and bump consumers