### PR TITLE
chore: release 2.0.0-beta.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.25",
+  "version": "2.0.0-beta.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-flic2",
-      "version": "2.0.0-beta.25",
+      "version": "2.0.0-beta.26",
       "license": "MIT",
       "devDependencies": {
         "@eslint/compat": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.25",
+  "version": "2.0.0-beta.26",
   "description": "React Native Flic plugin made with the Flic2 SDK (unofficial)",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump package version to `2.0.0-beta.26` to match the npm publish (release-it could not push the version commit directly to protected `develop`).
- Package already available: `npm view react-native-flic2@beta` → `2.0.0-beta.26`.

## Test plan
- [ ] Confirm version in package.json is 2.0.0-beta.26
- [ ] After merge, tag `v2.0.0-beta.26` if missing


Made with [Cursor](https://cursor.com)