### PR TITLE
fix(ios): remove super invalidate (NativeFlic2SpecBase)

### DIFF
--- a/ios/Flic2.mm
+++ b/ios/Flic2.mm
@@ -58,10 +58,10 @@ static BOOL Flic2ManagerDidRestoreOnce = NO;
     [self resolveInitializeIfPending];
 }
 
+// NativeFlic2SpecBase is NSObject — no invalidate. RN still calls this via respondsToSelector.
 - (void)invalidate
 {
     [self rejectInitializeIfPending:@"MODULE_INVALIDATED" message:@"Flic2 native module was invalidated"];
-    [super invalidate];
 }
 
 - (void)initialize:(BOOL)background

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.26",
+  "version": "2.0.0-beta.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-flic2",
-      "version": "2.0.0-beta.26",
+      "version": "2.0.0-beta.27",
       "license": "MIT",
       "devDependencies": {
         "@eslint/compat": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.26",
+  "version": "2.0.0-beta.27",
   "description": "React Native Flic plugin made with the Flic2 SDK (unofficial)",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary
- iOS builds fail because `NativeFlic2SpecBase` (NSObject) does not declare `invalidate`, so `[super invalidate]` does not compile.
- Keep `-invalidate` cleanup (reject pending init); RN still invokes it via `respondsToSelector`.

## Test plan
- [ ] `npm run lint` / `npm run typecheck`
- [ ] iOS build of a consumer app (e.g. xgac-rn-alarm) with this pod compiles past `Flic2.mm`
- [ ] Module remount still rejects in-flight `initialize` with `MODULE_INVALIDATED`


Made with [Cursor](https://cursor.com)