### PR TITLE
feat(android): defer FGS init until foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The library runs a foreground service to keep Flic2 buttons connected in the bac
 
 **Important:** For background usage, initialize Flic2 at the global level (outside of React components), typically in your app's entry point (e.g., `index.js` or `App.js`). Initializing in a `useEffect` is too late for background functionality.
 
+On Android, `initialize()` is safe to call anytime: if `Flic2Service` is already running it binds without starting a new foreground service (works headless/background). A cold start that must launch the foreground service may be deferred until the app is `active`. Cold boot still needs a brief app foreground window if the process/service is not already up — that is app-owned (e.g. your own `BOOT_COMPLETED` receiver), not provided by this library.
+
 ```tsx
 // index.js or App.js (global level, outside components)
 import Flic2, {
@@ -457,12 +459,21 @@ export default Flic2Example;
 
 ### Initialization
 
-#### `initialize(): Promise<void>`
+#### `initialize(options?: InitializeOptions): Promise<void>`
 
 Initialize the Flic2 manager. This must be called before using any other methods.
 
+Resolves when the native manager is ready. Concurrent and repeat calls share one in-flight promise.
+
+**Android:** Always attempts native init first. If the Flic foreground service is already running, binds without starting a new FGS (works in background/headless). If a cold start needs `startForegroundService` and Android blocks it, waits for `AppState` `active` and retries (including short capped retries when RN reports active but FGS is still blocked). Pass `{ waitForForeground: false }` to reject immediately with code `FGS_START_BLOCKED` instead of waiting.
+
+**iOS:** Unchanged — waits until the manager is restored / powered on.
+
 ```tsx
 await Flic2.initialize();
+
+// Optional: fail fast when Android cannot start the FGS from the background
+await Flic2.initialize({ waitForForeground: false });
 ```
 
 ### Scanning

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ The library runs a foreground service to keep Flic2 buttons connected in the bac
 
 **Important:** For background usage, initialize Flic2 at the global level (outside of React components), typically in your app's entry point (e.g., `index.js` or `App.js`). Initializing in a `useEffect` is too late for background functionality.
 
-On Android, `initialize()` is safe to call anytime: if `Flic2Service` is already running it binds without starting a new foreground service (works headless/background). A cold start that must launch the foreground service may be deferred until the app is `active`. Cold boot still needs a brief app foreground window if the process/service is not already up — that is app-owned (e.g. your own `BOOT_COMPLETED` receiver), not provided by this library.
+On Android, `initialize()` is safe to call anytime: if `Flic2Service` is already running it binds without starting a new foreground service (works headless/background). A cold start that must launch the foreground service may be deferred until the app is `active`.
+
+The library ships `BootUpReceiver` / `UpdateReceiver` (same process-wake pattern as 0.3.x): they ensure `Application.onCreate` has run after boot/update, but they do not start the Flic FGS themselves. If a cold FGS start needs a brief foreground Activity window, that remains app-owned.
 
 ```tsx
 // index.js or App.js (global level, outside components)

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
     <!-- Foreground service permission -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application>
         <service
@@ -23,28 +22,6 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />
-
-        <receiver
-            android:name=".Flic2Service$BootUpReceiver"
-            android:enabled="true"
-            android:permission="android.permission.RECEIVE_BOOT_COMPLETED"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </receiver>
-
-        <receiver
-            android:name=".Flic2Service$UpdateReceiver"
-            android:enabled="true"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="android.intent.action.PACKAGE_REPLACED" />
-                <data
-                    android:scheme="package" />
-            </intent-filter>
-        </receiver>
     </application>
 
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <!-- Foreground service permission -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application>
         <service
@@ -22,6 +23,28 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="connectedDevice" />
+
+        <receiver
+            android:name=".Flic2Service$BootUpReceiver"
+            android:enabled="true"
+            android:permission="android.permission.RECEIVE_BOOT_COMPLETED"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".Flic2Service$UpdateReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.PACKAGE_REPLACED" />
+                <data
+                    android:scheme="package" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/android/src/main/java/nl/xguard/flic2/ActivityUtil.kt
+++ b/android/src/main/java/nl/xguard/flic2/ActivityUtil.kt
@@ -1,12 +1,12 @@
 package nl.xguard.flic2
 
 import android.app.ActivityManager
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 
 object ActivityUtil {
-    private const val TAG = "ActivityUtil"
 
     fun isServiceRunning(context: Context, serviceClass: Class<*>): Boolean {
         val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
@@ -25,5 +25,30 @@ object ActivityUtil {
             context.startService(intent)
         }
     }
-}
 
+    /**
+     * True when Android refused starting a foreground service from the background.
+     * Used so JS can defer initialize() until the app is active again.
+     */
+    fun isForegroundServiceStartBlocked(error: Throwable): Boolean {
+        var current: Throwable? = error
+        while (current != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                && current is ForegroundServiceStartNotAllowedException
+            ) {
+                return true
+            }
+
+            val message = current.message.orEmpty()
+            if (message.contains("ForegroundServiceStartNotAllowed")
+                || message.contains("mAllowStartForeground")
+                || message.contains("startForegroundService() not allowed")
+            ) {
+                return true
+            }
+
+            current = current.cause
+        }
+        return false
+    }
+}

--- a/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Module.kt
@@ -188,10 +188,26 @@ class Flic2Module(reactContext: ReactApplicationContext) :
 
       val intent = Intent(reactApplicationContext, Flic2Service::class.java)
 
-      // Check if service is already running
+      // Soft path: service already up → bind only (works headless / background).
+      // Cold start needs startForegroundService, which Android may block while backgrounded.
       if (!ActivityUtil.isServiceRunning(reactApplicationContext, Flic2Service::class.java)) {
-        // Start service
-        ActivityUtil.startForegroundService(reactApplicationContext, intent)
+        try {
+          ActivityUtil.startForegroundService(reactApplicationContext, intent)
+        } catch (e: Exception) {
+          initializePromise = null
+          if (ActivityUtil.isForegroundServiceStartBlocked(e)) {
+            Log.w(TAG, "Foreground service start blocked", e)
+            promise.reject(
+              "FGS_START_BLOCKED",
+              "Cannot start Flic2 foreground service while backgrounded",
+              e
+            )
+          } else {
+            Log.e(TAG, "Failed to start Flic2Service", e)
+            promise.reject("INIT_ERROR", "Failed to start Flic2 service: ${e.message}", e)
+          }
+          return
+        }
       }
 
       // Bind to service - promise will be resolved in onServiceConnected
@@ -208,7 +224,15 @@ class Flic2Module(reactContext: ReactApplicationContext) :
     } catch (e: Exception) {
       Log.e(TAG, "Failed to initialize", e)
       initializePromise = null
-      promise.reject("INIT_ERROR", "Failed to initialize: ${e.message}", e)
+      if (ActivityUtil.isForegroundServiceStartBlocked(e)) {
+        promise.reject(
+          "FGS_START_BLOCKED",
+          "Cannot start Flic2 foreground service while backgrounded",
+          e
+        )
+      } else {
+        promise.reject("INIT_ERROR", "Failed to initialize: ${e.message}", e)
+      }
     }
   }
 

--- a/android/src/main/java/nl/xguard/flic2/Flic2Service.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Service.kt
@@ -5,7 +5,6 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -255,20 +254,5 @@ class Flic2Service : Service() {
         }
     }
 
-    // BootUpReceiver for handling device boot
-    class BootUpReceiver : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            Log.d(TAG, "BootUpReceiver()")
-            // The Application class's onCreate has already been called at this point, which is what we want
-        }
-    }
-
-    // UpdateReceiver for handling app updates
-    class UpdateReceiver : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            Log.d(TAG, "UpdateReceiver()")
-            // The Application class's onCreate has already been called at this point, which is what we want
-        }
-    }
 }
 

--- a/android/src/main/java/nl/xguard/flic2/Flic2Service.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Service.kt
@@ -5,6 +5,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -254,5 +255,20 @@ class Flic2Service : Service() {
         }
     }
 
+    // Same pattern as 0.3.x / master: wake the process on boot / package replace.
+    // Application.onCreate has already run; FGS cold-start still needs a later initialize().
+    class BootUpReceiver : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            Log.d(TAG, "BootUpReceiver()")
+            // The Application class's onCreate has already been called at this point, which is what we want
+        }
+    }
+
+    class UpdateReceiver : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            Log.d(TAG, "UpdateReceiver()")
+            // The Application class's onCreate has already been called at this point, which is what we want
+        }
+    }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.27",
+  "version": "2.0.0-beta.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-flic2",
-      "version": "2.0.0-beta.27",
+      "version": "2.0.0-beta.28",
       "license": "MIT",
       "devDependencies": {
         "@eslint/compat": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-flic2",
-  "version": "2.0.0-beta.27",
+  "version": "2.0.0-beta.28",
   "description": "React Native Flic plugin made with the Flic2 SDK (unofficial)",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+import {
+  AppState,
+  Platform,
+  type AppStateStatus,
+  type NativeEventSubscription,
+} from 'react-native';
 import { TypedEmitter } from './lib/typedEventEmitter';
 import NativeFlic2, {
   type ButtonEvent,
@@ -7,6 +13,19 @@ import NativeFlic2, {
   type ScanStatusChangeEvent,
   type TriggerModeType,
 } from './NativeFlic2';
+
+export type InitializeOptions = {
+  /**
+   * Android only. When a cold start needs a foreground service and Android
+   * blocks it while backgrounded, wait for `AppState` `active` and retry
+   * (default `true`). Set `false` to reject immediately with `FGS_START_BLOCKED`.
+   */
+  waitForForeground?: boolean;
+};
+
+const FGS_START_BLOCKED = 'FGS_START_BLOCKED';
+const ACTIVE_FGS_RETRY_MAX = 3;
+const ACTIVE_FGS_RETRY_DELAY_MS = 500;
 
 class Flic2 {
 
@@ -54,9 +73,15 @@ class Flic2 {
    * Idempotent: concurrent and repeat calls share one in-flight promise
    * or return immediately once ready.
    *
+   * On Android, always attempts native init first (bind-only when the Flic
+   * service is already running — works headless/background). If a cold start
+   * needs a foreground service and Android blocks it, waits for the app to
+   * become active and retries unless `waitForForeground: false`.
+   *
+   * @param options - Optional initialize behavior.
    * @returns A promise that resolves when the Flic2 manager is ready.
    */
-  public async initialize(): Promise<void> {
+  public async initialize(options?: InitializeOptions): Promise<void> {
 
     if (this.isInitialized()) {
 
@@ -70,9 +95,11 @@ class Flic2 {
 
     }
 
+    const waitForForeground = options?.waitForForeground !== false;
+
     this.initializePromise = (async () => {
 
-      await NativeFlic2.initialize(true);
+      await this.initializeNative(waitForForeground);
       this.onInitialized();
 
     })().finally(() => {
@@ -319,6 +346,160 @@ class Flic2 {
   private isBatteryVoltageOk(voltage: number): boolean {
 
     return voltage * 1000 > 2650;
+
+  }
+
+  private isFgsStartBlocked(error: unknown): boolean {
+
+    if (Platform.OS !== 'android') {
+
+      return false;
+
+    }
+
+    return typeof error === 'object'
+      && error !== null
+      && 'code' in error
+      && (error as { code: unknown }).code === FGS_START_BLOCKED;
+
+  }
+
+  private async initializeNative(waitForForeground: boolean): Promise<void> {
+
+    try {
+
+      await NativeFlic2.initialize(true);
+
+    } catch (error) {
+
+      if (!waitForForeground || !this.isFgsStartBlocked(error)) {
+
+        throw error;
+
+      }
+
+      await this.waitForForegroundAndRetryNativeInit();
+
+    }
+
+  }
+
+  /**
+   * After FGS_START_BLOCKED: wait for AppState active and retry native init.
+   * When already active, capped delayed retries cover the RN-active / FGS-race.
+   */
+  private waitForForegroundAndRetryNativeInit(): Promise<void> {
+
+    return new Promise((resolve, reject) => {
+
+      let activeRetryCount = 0;
+      let activeRetryTimeout: ReturnType<typeof setTimeout> | undefined;
+      let subscription: NativeEventSubscription | undefined;
+
+      const cleanup = () => {
+
+        subscription?.remove();
+        subscription = undefined;
+
+        if (activeRetryTimeout !== undefined) {
+
+          clearTimeout(activeRetryTimeout);
+          activeRetryTimeout = undefined;
+
+        }
+
+      };
+
+      const tryNativeInit = async () => {
+
+        try {
+
+          await NativeFlic2.initialize(true);
+          cleanup();
+          resolve();
+
+        } catch (error) {
+
+          if (!this.isFgsStartBlocked(error)) {
+
+            cleanup();
+            reject(error);
+            return;
+
+          }
+
+          scheduleActiveRetry();
+
+        }
+
+      };
+
+      const scheduleActiveRetry = () => {
+
+        if (AppState.currentState !== 'active') {
+
+          return;
+
+        }
+
+        if (activeRetryCount >= ACTIVE_FGS_RETRY_MAX) {
+
+          // Budget spent this foreground session; wait for next active entry.
+          return;
+
+        }
+
+        activeRetryCount += 1;
+
+        if (activeRetryTimeout !== undefined) {
+
+          clearTimeout(activeRetryTimeout);
+
+        }
+
+        activeRetryTimeout = setTimeout(() => {
+
+          activeRetryTimeout = undefined;
+
+          if (AppState.currentState === 'active') {
+
+            tryNativeInit().catch(() => undefined);
+
+          }
+
+        }, ACTIVE_FGS_RETRY_DELAY_MS);
+
+      };
+
+      const onAppStateChange = (nextAppState: AppStateStatus) => {
+
+        if (nextAppState !== 'active') {
+
+          if (activeRetryTimeout !== undefined) {
+
+            clearTimeout(activeRetryTimeout);
+            activeRetryTimeout = undefined;
+
+          }
+
+          activeRetryCount = 0;
+          return;
+
+        }
+
+        tryNativeInit().catch(() => undefined);
+
+      };
+
+      subscription = AppState.addEventListener('change', onAppStateChange);
+
+      if (AppState.currentState === 'active') {
+
+        scheduleActiveRetry();
+
+      }
+
+    });
 
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -428,13 +428,13 @@ class Flic2 {
 
           }
 
-          scheduleActiveRetry();
+          scheduleActiveRetry(error);
 
         }
 
       };
 
-      const scheduleActiveRetry = () => {
+      const scheduleActiveRetry = (lastError?: unknown) => {
 
         if (AppState.currentState !== 'active') {
 
@@ -444,7 +444,9 @@ class Flic2 {
 
         if (activeRetryCount >= ACTIVE_FGS_RETRY_MAX) {
 
-          // Budget spent this foreground session; wait for next active entry.
+          // Stay-active + still blocked: fail instead of hanging forever.
+          cleanup();
+          reject(lastError ?? new Error(FGS_START_BLOCKED));
           return;
 
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,8 @@ class Flic2 {
    * Resolves when the native manager is ready for API calls
    * (`getButtons`, `connectAllKnownButtons`, `startScan`, etc.).
    * Idempotent: concurrent and repeat calls share one in-flight promise
-   * or return immediately once ready.
+   * or return immediately once ready. Options apply only to the call that
+   * starts that promise; later concurrent callers inherit its behavior.
    *
    * On Android, always attempts native init first (bind-only when the Flic
    * service is already running — works headless/background). If a cold start


### PR DESCRIPTION
## Summary
- Android cold `initialize()` rejects with stable `FGS_START_BLOCKED` when `startForegroundService` is blocked; bind-only soft path still works when `Flic2Service` is already running (headless/background).
- JS `initialize()` waits for `AppState` `active` and retries (capped 3×500ms when already active) by default; `{ waitForForeground: false }` fails fast; reject after retry budget instead of hanging.
- Keep library `BootUpReceiver` / `UpdateReceiver`; they now **try** to start `Flic2Service` on boot/update (official flic2lib-android intent), failing soft if blocked.
- Bump to `2.0.0-beta.28`.

## Follow-up (apps)
`xgac-rn-alarm` currently `tools:node="remove"`s `Flic2Service$BootUpReceiver`, so it will not get this library boot FGS try until that remove is dropped (keep app `OnBootReceiver` for Activity if needed).

## Test plan
- [ ] Foreground: `await Flic2.initialize()` resolves; buttons APIs work
- [ ] Background soft-bind: with Flic2Service already up, initialize from headless/background resolves without FGS start
- [ ] Cold start while backgrounded: initialize waits / retries until app becomes active (or rejects with `FGS_START_BLOCKED` when `waitForForeground: false`)
- [ ] Boot/update: receivers attempt `startForegroundService` (may log failure if blocked); service `onCreate` inits manager when start succeeds
- [ ] iOS initialize unchanged