### PR TITLE
feat(android): try start Flic2Service from boot/update receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The library runs a foreground service to keep Flic2 buttons connected in the bac
 
 On Android, `initialize()` is safe to call anytime: if `Flic2Service` is already running it binds without starting a new foreground service (works headless/background). A cold start that must launch the foreground service may be deferred until the app is `active`.
 
-The library ships `BootUpReceiver` / `UpdateReceiver` (same process-wake pattern as 0.3.x): they ensure `Application.onCreate` has run after boot/update, but they do not start the Flic FGS themselves. If a cold FGS start needs a brief foreground Activity window, that remains app-owned.
+The library ships `BootUpReceiver` / `UpdateReceiver` (same process-wake pattern as official flic2lib-android / 0.3.x). After boot or package replace they **try** to start `Flic2Service` via `startForegroundService`. That start may still be blocked on modern Android; a brief app foreground Activity window can still be required. JS `initialize()` remains required for the React Native bridge and event listeners.
 
 ```tsx
 // index.js or App.js (global level, outside components)

--- a/android/src/main/java/nl/xguard/flic2/Flic2Service.kt
+++ b/android/src/main/java/nl/xguard/flic2/Flic2Service.kt
@@ -38,6 +38,23 @@ class Flic2Service : Service() {
         private const val NOTIFICATION_ICON_KEY = "nl.xguard.flic2.notification_icon"
         private const val NOTIFICATION_ID_KEY = "nl.xguard.flic2.notification_id"
         private const val CHANNEL_ID_KEY = "nl.xguard.flic2.notification_channel_id"
+
+        /**
+         * Official flic2lib-android starts the FGS from Application.onCreate after boot/update
+         * wake. We cannot hook the host Application, so receivers try startForegroundService here.
+         * Modern Android may still block this; JS initialize() / app UI cover that path.
+         */
+        private fun tryStartFromBootOrUpdate(context: Context) {
+            try {
+                val appContext = context.applicationContext
+                ActivityUtil.startForegroundService(
+                    appContext,
+                    Intent(appContext, Flic2Service::class.java)
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to start Flic2Service from boot/update receiver", e)
+            }
+        }
     }
 
     inner class Flic2ServiceBinder : Binder() {
@@ -255,19 +272,19 @@ class Flic2Service : Service() {
         }
     }
 
-    // Same pattern as 0.3.x / master: wake the process on boot / package replace.
-    // Application.onCreate has already run; FGS cold-start still needs a later initialize().
+    // Wake process on boot / package replace, then try to start Flic2Service (FGS).
+    // Application.onCreate has already run; JS initialize() is still required for the RN bridge.
     class BootUpReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             Log.d(TAG, "BootUpReceiver()")
-            // The Application class's onCreate has already been called at this point, which is what we want
+            tryStartFromBootOrUpdate(context)
         }
     }
 
     class UpdateReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             Log.d(TAG, "UpdateReceiver()")
-            // The Application class's onCreate has already been called at this point, which is what we want
+            tryStartFromBootOrUpdate(context)
         }
     }
 }


### PR DESCRIPTION
## Summary
- `BootUpReceiver` / `UpdateReceiver` now try `startForegroundService(Flic2Service)` after boot/package-replace process wake (official flic2lib-android intent).
- Fail soft if Android blocks background FGS start; JS `initialize()` remains required for the RN bridge.
- Follow-up: `xgac-rn-alarm` still `tools:node="remove"`s the library boot receiver, so it will not get this until that remove is dropped.

## Test plan
- [ ] Boot/update: receivers attempt `startForegroundService`; service `onCreate` inits manager when start succeeds
- [ ] If start is blocked, warning is logged and app can still initialize via foreground + `Flic2.initialize()`
- [ ] Soft-bind path still works when service is already running


Made with [Cursor](https://cursor.com)