### PR TITLE
docs: add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # react-native-flic2
 
+[![npm version](https://img.shields.io/npm/v/react-native-flic2.svg)](https://www.npmjs.com/package/react-native-flic2)
+
 React Native library for integrating Flic2 buttons into your React Native application. This library provides a complete interface to discover, connect, and interact with Flic2 buttons on both iOS and Android platforms.
 
 ## Features


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or security impact.
> 
> **Overview**
> Adds an **npm version** shields.io badge at the top of `README.md`, directly under the project title, linking to the package on npm.com.
> 
> This is documentation-only; it does not change library behavior or APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597e9bf248ade881ee7c3cc99bb8dcfe6b5e9e45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->